### PR TITLE
Fixed build error and CMD execution warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ WORKDIR /home/opam/interproc
 
 RUN opam depext -i interproc
 
-RUN eval $(opam env) && \
-  sudo make all
+RUN sudo chown -R opam:opam /home/opam/interproc
+RUN opam exec -- make all
 
 
 FROM httpd:2.4.58-alpine AS server
@@ -57,6 +57,6 @@ RUN echo "LoadModule cgid_module modules/mod_cgid.so" >> conf/httpd.conf
 RUN echo "LoadModule cgid_module modules/mod_rewrite.so" >> conf/httpd.conf
 RUN echo "DirectoryIndex interproc.html" >> conf/httpd.conf
 
-CMD httpd-foreground
+CMD ["httpd-foreground"]
 
 EXPOSE 80


### PR DESCRIPTION
Building the image as instructed resulted in the following build error:

```
 => ERROR [build 18/18] RUN eval $(opam env) &&   sudo make all                                                                                                      0.2s
------
 > [build 18/18] RUN eval $(opam env) &&   sudo make all:
0.199 make: dune: No such file or directory
0.199 make: *** [Makefile:5: build] Error 127
------
```

The build process works if the command is issued through opam exec, but it requires the opam user to own the inteproc directory.

Furthermore, running `CMD httpd-foreground` produced the following warning:

```
 1 warning found:
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 60)
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
Dockerfile:60
--------------------
  58 |     RUN echo "DirectoryIndex interproc.html" >> conf/httpd.conf
  59 |     
  60 | >>> CMD httpd-foreground
  61 |     
  62 |     EXPOSE 80
--------------------
```

Simply using the suggested format for running commands solved this.